### PR TITLE
expand retry to include read config map

### DIFF
--- a/cmd/cli/remove.go
+++ b/cmd/cli/remove.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var removeArgs = &mapper.RemoveArguments{}
+var removeArgs = &mapper.MapperArguments{}
 
 // deleteCmd represents the base command when called without any subcommands
 var removeCmd = &cobra.Command{
@@ -45,7 +45,7 @@ var removeCmd = &cobra.Command{
 
 // removeByUsernameCmd removes all map roles and map users in an auth cm based on the input username
 func removeByUsernameCmd() *cobra.Command {
-	var removeArgs = &mapper.RemoveArguments{}
+	var removeArgs = &mapper.MapperArguments{}
 	var command = &cobra.Command{
 		Use:   "remove-by-username",
 		Short: "remove-by-username removes all map roles and map users from the aws-auth configmap",

--- a/cmd/cli/remove.go
+++ b/cmd/cli/remove.go
@@ -23,7 +23,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var removeArgs = &mapper.MapperArguments{}
+var removeArgs = &mapper.MapperArguments{
+	OperationType: mapper.OperationRemove,
+}
 
 // deleteCmd represents the base command when called without any subcommands
 var removeCmd = &cobra.Command{

--- a/cmd/cli/upsert.go
+++ b/cmd/cli/upsert.go
@@ -23,7 +23,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var upsertArgs = &mapper.UpsertArguments{}
+var upsertArgs = &mapper.MapperArguments{}
 
 // upsertCmd represents the base command when called without any subcommands
 var upsertCmd = &cobra.Command{

--- a/cmd/cli/upsert.go
+++ b/cmd/cli/upsert.go
@@ -23,7 +23,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var upsertArgs = &mapper.MapperArguments{}
+var upsertArgs = &mapper.MapperArguments{
+	OperationType: mapper.OperationUpsert,
+}
 
 // upsertCmd represents the base command when called without any subcommands
 var upsertCmd = &cobra.Command{

--- a/example/example.go
+++ b/example/example.go
@@ -23,7 +23,7 @@ func main() {
 	}
 
 	awsAuth := awsauth.New(client, false)
-	myUpsertRole := &awsauth.UpsertArguments{
+	myUpsertRole := &awsauth.MapperArguments{
 		MapRoles: true,
 		RoleARN:  "arn:aws:iam::555555555555:role/my-new-node-group-NodeInstanceRole-74RF4UBDUKL6",
 		Username: "system:node:{{EC2PrivateDNSName}}",
@@ -39,7 +39,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	myDeleteRole := &awsauth.RemoveArguments{
+	myDeleteRole := &awsauth.MapperArguments{
 		MapRoles: true,
 		RoleARN:  "arn:aws:iam::555555555555:role/my-new-node-group-NodeInstanceRole-74RF4UBDUKL6",
 		Username: "system:node:{{EC2PrivateDNSName}}",

--- a/pkg/mapper/configmaps_test.go
+++ b/pkg/mapper/configmaps_test.go
@@ -18,7 +18,6 @@ package mapper
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -79,45 +78,6 @@ func TestConfigMaps_Update(t *testing.T) {
 	fmt.Println(auth.MapRoles[0])
 	g.Expect(len(auth.MapRoles)).To(gomega.Equal(2))
 	g.Expect(len(auth.MapUsers)).To(gomega.Equal(2))
-}
-
-func TestConfigMaps_UpdateRetries(t *testing.T) {
-	g := gomega.NewWithT(t)
-	gomega.RegisterTestingT(t)
-	client := fake.NewSimpleClientset()
-	create_MockConfigMap(client)
-
-	auth, cm, err := ReadAuthMap(client)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	role := NewRolesAuthMap("arn:aws:iam::00000000000:role/node-2",
-		"system:node:{{EC2PrivateDNSName}}",
-		[]string{"system:bootstrappers", "system:nodes"})
-	user := NewUsersAuthMap("arn:aws:iam::00000000000:user/user-2",
-		"ops-user",
-		[]string{"system:masters"})
-
-	auth.MapRoles = append(auth.MapRoles, role)
-	auth.MapUsers = append(auth.MapUsers, user)
-	retryer := &RetryConfig{
-		MinRetryTime:  time.Millisecond * 1,
-		MaxRetryTime:  time.Millisecond * 2,
-		MaxRetryCount: 3,
-	}
-
-	err = UpdateAuthMapWithRetries(client, auth, cm, retryer)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	auth, cm, err = ReadAuthMap(client)
-	g.Expect(err).NotTo(gomega.HaveOccurred())
-
-	fmt.Println(auth.MapRoles[0])
-	g.Expect(len(auth.MapRoles)).To(gomega.Equal(2))
-	g.Expect(len(auth.MapUsers)).To(gomega.Equal(2))
-
-	client.CoreV1().ConfigMaps("kube-system").Delete("aws-auth", &metav1.DeleteOptions{})
-	err = UpdateAuthMapWithRetries(client, auth, cm, retryer)
-	g.Expect(err).To(gomega.HaveOccurred())
 }
 
 func TestConfigMaps_Read(t *testing.T) {

--- a/pkg/mapper/remove_test.go
+++ b/pkg/mapper/remove_test.go
@@ -30,7 +30,7 @@ func TestMapper_Remove(t *testing.T) {
 	mapper := New(client, true)
 	create_MockConfigMap(client)
 
-	err := mapper.Remove(&RemoveArguments{
+	err := mapper.Remove(&MapperArguments{
 		MapRoles: true,
 		RoleARN:  "arn:aws:iam::00000000000:role/node-1",
 		Username: "system:node:{{EC2PrivateDNSName}}",
@@ -38,7 +38,7 @@ func TestMapper_Remove(t *testing.T) {
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	err = mapper.Remove(&RemoveArguments{
+	err = mapper.Remove(&MapperArguments{
 		MapUsers: true,
 		UserARN:  "arn:aws:iam::00000000000:user/user-1",
 		Username: "admin",
@@ -59,13 +59,13 @@ func TestMapper_RemoveByARN(t *testing.T) {
 	mapper := New(client, true)
 	create_MockConfigMap(client)
 
-	err := mapper.Remove(&RemoveArguments{
+	err := mapper.Remove(&MapperArguments{
 		MapRoles: true,
 		RoleARN:  "arn:aws:iam::00000000000:role/node-1",
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	err = mapper.Remove(&RemoveArguments{
+	err = mapper.Remove(&MapperArguments{
 		MapUsers: true,
 		UserARN:  "arn:aws:iam::00000000000:user/user-1",
 	})
@@ -84,13 +84,13 @@ func TestMapper_RemoveNotFound(t *testing.T) {
 	mapper := New(client, true)
 	create_MockConfigMap(client)
 
-	err := mapper.Remove(&RemoveArguments{
+	err := mapper.Remove(&MapperArguments{
 		MapRoles: true,
 		RoleARN:  "arn:aws:iam::00000000000:role/node-2",
 	})
 	g.Expect(err).To(gomega.HaveOccurred())
 
-	err = mapper.Remove(&RemoveArguments{
+	err = mapper.Remove(&MapperArguments{
 		MapUsers: true,
 		UserARN:  "arn:aws:iam::00000000000:user/user-2",
 	})
@@ -109,7 +109,7 @@ func TestMapper_RemoveByUsername(t *testing.T) {
 	mapper := New(client, true)
 	create_MockConfigMap(client)
 
-	err := mapper.RemoveByUsername(&RemoveArguments{
+	err := mapper.RemoveByUsername(&MapperArguments{
 		Username: "system:node:{{EC2PrivateDNSName}}",
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
@@ -119,7 +119,7 @@ func TestMapper_RemoveByUsername(t *testing.T) {
 	g.Expect(len(auth.MapRoles)).To(gomega.Equal(0))
 	g.Expect(len(auth.MapUsers)).To(gomega.Equal(1))
 
-	err = mapper.RemoveByUsername(&RemoveArguments{
+	err = mapper.RemoveByUsername(&MapperArguments{
 		Username: "admin",
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
@@ -137,7 +137,7 @@ func TestMapper_RemoveByUsernameWithRetries(t *testing.T) {
 	mapper := New(client, true)
 	create_MockConfigMap(client)
 
-	err := mapper.RemoveByUsername(&RemoveArguments{
+	err := mapper.RemoveByUsername(&MapperArguments{
 		Username:      "system:node:{{EC2PrivateDNSName}}",
 		WithRetries:   true,
 		MinRetryTime:  time.Millisecond * 1,
@@ -151,7 +151,7 @@ func TestMapper_RemoveByUsernameWithRetries(t *testing.T) {
 	g.Expect(len(auth.MapRoles)).To(gomega.Equal(0))
 	g.Expect(len(auth.MapUsers)).To(gomega.Equal(1))
 
-	err = mapper.RemoveByUsername(&RemoveArguments{
+	err = mapper.RemoveByUsername(&MapperArguments{
 		Username:      "admin",
 		WithRetries:   true,
 		MinRetryTime:  time.Millisecond * 1,
@@ -173,7 +173,7 @@ func TestMapper_RemoveByUsernameNotFound(t *testing.T) {
 	mapper := New(client, true)
 	create_MockConfigMap(client)
 
-	err := mapper.RemoveByUsername(&RemoveArguments{
+	err := mapper.RemoveByUsername(&MapperArguments{
 		Username: "",
 	})
 	g.Expect(err).To(gomega.HaveOccurred())
@@ -191,7 +191,7 @@ func TestMapper_RemoveWithRetries(t *testing.T) {
 	mapper := New(client, true)
 	create_MockConfigMap(client)
 
-	err := mapper.Remove(&RemoveArguments{
+	err := mapper.Remove(&MapperArguments{
 		MapRoles:      true,
 		RoleARN:       "arn:aws:iam::00000000000:role/node-1",
 		Username:      "system:node:{{EC2PrivateDNSName}}",
@@ -203,7 +203,7 @@ func TestMapper_RemoveWithRetries(t *testing.T) {
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
-	err = mapper.Remove(&RemoveArguments{
+	err = mapper.Remove(&MapperArguments{
 		MapUsers:      true,
 		UserARN:       "arn:aws:iam::00000000000:user/user-1",
 		Username:      "admin",

--- a/pkg/mapper/types.go
+++ b/pkg/mapper/types.go
@@ -103,6 +103,10 @@ func (args *MapperArguments) Validate() {
 		log.Fatal("error: --mapusers and --maproles are mutually exclusive")
 	}
 
+	if args.Username == "" {
+		log.Fatal("error: --username not provided")
+	}
+
 	if !args.MapUsers && !args.MapRoles {
 		if !args.IsGlobal {
 			log.Fatal("error: must select --mapusers or --maproles")

--- a/pkg/mapper/types.go
+++ b/pkg/mapper/types.go
@@ -68,9 +68,17 @@ func (m *AwsAuthData) SetMapUsers(authMap []*UsersAuthMap) {
 	m.MapUsers = authMap
 }
 
+type OperationType string
+
+const (
+	OperationUpsert OperationType = "upsert"
+	OperationRemove OperationType = "remove"
+)
+
 // MapperArguments are the arguments for removing a mapRole or mapUsers
 type MapperArguments struct {
 	KubeconfigPath string
+	OperationType  OperationType
 	MapRoles       bool
 	MapUsers       bool
 	Username       string
@@ -103,7 +111,7 @@ func (args *MapperArguments) Validate() {
 		log.Fatal("error: --mapusers and --maproles are mutually exclusive")
 	}
 
-	if args.Username == "" {
+	if args.OperationType == OperationUpsert && args.Username == "" {
 		log.Fatal("error: --username not provided")
 	}
 


### PR DESCRIPTION
Fixes #13 
This unifies UpsertArguments & RemoveArguments types to a single type MapperArguments.
Refactors upsert / remove methods to be wrapped by the retry function