### PR TITLE
Multi arch docker build

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -47,6 +47,6 @@ jobs:
       with:
         context: .
         file: ./Dockerfile
-        platforms: linux/amd64
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: ${{ steps.docker_meta.outputs.tags }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -38,7 +38,7 @@ jobs:
 
     - name: Docker meta
       id: docker_meta
-      uses: crazy-max/ghaction-docker-meta@v1
+      uses: docker/metadata-action@v3
       with:
         images: ${{ github.repository_owner }}/aws-auth
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17-alpine
+FROM golang:1.17-alpine as build
 
 RUN apk add --update --no-cache \
     curl \
@@ -12,9 +12,12 @@ COPY . .
 RUN git rev-parse HEAD
 RUN date +%FT%T%z
 RUN make build
-RUN cp ./bin/aws-auth /bin/aws-auth \
-    && chmod +x /bin/aws-auth
-ENV HOME /root
+RUN chmod +x ./bin/aws-auth
 
+# Now copy it into our base image.
+FROM gcr.io/distroless/base-debian11
+COPY --from=build /go/src/github.com/keikoproj/aws-auth/bin/aws-auth /bin/aws-auth
+
+ENV HOME /root
 ENTRYPOINT ["/bin/aws-auth"]
 CMD ["help"]


### PR DESCRIPTION
I stumbled upon this tool whilst perusing the [AWS EKS Best Practices Guide](https://aws.github.io/aws-eks-best-practices/security/docs/iam/#use-a-tool-like-eksctl-to-make-changes-to-the-aws-auth-configmap), and it seems like a great way to improve on how we're currently managing updates to our aws-auth configmap with Terraform.

One thing that's missing, though, is a docker image built for the arm64 architecture. With the rapid rise of Graviton2 and Apple Silicon, I can't imagine I'll be the first person to need an arm64 image to work with an EKS cluster.

While I was here, I updated the Docker meta build step to use the official `docker/metadata-action` to replace the `crazy-max/ghaction-docker-buildx` predecessor. You can see the guidance to do so in [the repo](https://github.com/crazy-max/ghaction-docker-buildx) for the old action.

Finally, I updated the Dockerfile to use multi-stage builds. This keeps the same build behavior that was in place before, but instead of having users download a docker image with the entire go buildchain, git, curl, aws cli, etc, the final assembled image is built on a [Distroless base](https://github.com/GoogleContainerTools/distroless) to reduce the surface area and risk of the container that will ultimately run.

If you need me to break out any of these changes from the others, or if you're only interested in a subset of the changes, let me know, and I can rework this PR.

Here's [a test build in GH Actions](https://github.com/acmcelwee/aws-auth/actions/runs/2059914326) where I ran through the entire docker build/push workflow, with the push going to [my Docker Hub repo](https://hub.docker.com/repository/docker/amcelwee/aws-auth/tags?page=1&ordering=last_updated).