### PR TITLE
Added yaml manifest file to install aws-auth as a krew plugin

### DIFF
--- a/aws-auth.yaml
+++ b/aws-auth.yaml
@@ -26,7 +26,7 @@ spec:
     # 'uri' specifies .zip or .tar.gz archive URL of a plugin
     uri: https://github.com/jicowan/aws-auth/blob/master/aws-auth.tar.gz
     # 'sha256' is the sha256sum of the url above
-    sha256: 50931dfe8c1e6b1e73c952bfc05ed3c13f82a209366275ea018b421e097331dc
+    sha256: 5e2e362f31557487133007684bcc8dd010ad73d3bf2b554eb7e51c68cc004611
     # 'files' lists which files should be extracted out from downloaded archive
     files:
     - from: "aws-auth"

--- a/aws-auth.yaml
+++ b/aws-auth.yaml
@@ -1,0 +1,35 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  # 'name' must match the filename of the manifest. The name defines how
+  # the plugin is invoked, for example: `kubectl restart`
+  name: aws-auth
+spec:
+  # 'version' is a valid semantic version string (see semver.org)
+  version: "v0.0.1"
+  # 'homepage' usually links to the GitHub repository of the plugin
+  homepage: https://github.com/jicowan/aws-auth
+  # 'shortDescription' explains what the plugin does in only a few words
+  shortDescription: "Makes the management of the aws-auth config map for EKS Kubernetes clusters easier"
+  description: |
+    Useful for automation purposes, any workflow that needs 
+    to grant IAM access to an EKS cluster can use this plugin 
+    to modify the config map.
+  # 'platforms' specify installation methods for various platforms (os/arch)
+  platforms:
+  - selector:
+      matchExpressions:
+      - key: "os"
+        operator: "In"
+        values:
+        - darwin
+    # 'uri' specifies .zip or .tar.gz archive URL of a plugin
+    uri: https://github.com/achanda/kubectl-restart/archive/v0.0.3.zip
+    # 'sha256' is the sha256sum of the url above
+    sha256: d7079b79bf4e10e55ded435a2e862efe310e019b6c306a8ff04191238ef4b2b4
+    # 'files' lists which files should be extracted out from downloaded archive
+    files:
+    - from: "aws-auth"
+      to: "./aws-auth"
+    # 'bin' specifies the path to the the plugin executable among extracted files
+    bin: aws-auth

--- a/aws-auth.yaml
+++ b/aws-auth.yaml
@@ -30,6 +30,6 @@ spec:
     # 'files' lists which files should be extracted out from downloaded archive
     files:
     - from: "aws-auth"
-      to: "./aws-auth"
+      to: "aws-auth"
     # 'bin' specifies the path to the the plugin executable among extracted files
     bin: aws-auth

--- a/aws-auth.yaml
+++ b/aws-auth.yaml
@@ -24,9 +24,9 @@ spec:
         values:
         - darwin
     # 'uri' specifies .zip or .tar.gz archive URL of a plugin
-    uri: https://github.com/achanda/kubectl-restart/archive/v0.0.3.zip
+    uri: https://github.com/jicowan/aws-auth/blob/master/aws-auth.tar.gz
     # 'sha256' is the sha256sum of the url above
-    sha256: d7079b79bf4e10e55ded435a2e862efe310e019b6c306a8ff04191238ef4b2b4
+    sha256: 50931dfe8c1e6b1e73c952bfc05ed3c13f82a209366275ea018b421e097331dc
     # 'files' lists which files should be extracted out from downloaded archive
     files:
     - from: "aws-auth"

--- a/checksum.txt
+++ b/checksum.txt
@@ -1,1 +1,0 @@
-https://github.com/jicowan/aws-auth/blob/master/aws-auth.tar.gz

--- a/checksum.txt
+++ b/checksum.txt
@@ -1,0 +1,1 @@
+https://github.com/jicowan/aws-auth/blob/master/aws-auth.tar.gz


### PR DESCRIPTION
You will need to update the SHA for the tarball since the location is changing. This pull request also includes a tarball that contains the binary for Darwin. You may want to include versions for Windows and Linux. This PR doesn't implement all of the recommended (best practices)[https://krew.sigs.k8s.io/docs/developer-guide/develop/best-practices/] for Krew plugin.