### PR TITLE
feat: add UpsertOptions to support appending groups and not overwriting username

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,29 +125,16 @@ Retries are configurable using the following flags
       --retry-min-time duration   Minimum wait interval (default 200ms)
 ```
 
-
-Append group if iam role already exists
-
-```
-aws-auth upsert  --maproles --rolearn arn:aws:iam::00000000000:role/test  --username test   --groups test --append
-```
-
-Append group if iam user already exists
+Append groups to mapping instead of overwriting by using --append
 
 ```
-aws-auth upsert  --maproles --rolearn arn:aws:iam::00000000000:role/test  --username test   --groups test --append
+aws-auth upsert --maproles --rolearn arn:aws:iam::00000000000:role/test --username test --groups test --append
 ```
 
-Update username during upsert (default is true)
+Avoid overwriting username by using --update-username=false
 
 ```
-aws-auth upsert  --maproles --rolearn arn:aws:iam::00000000000:role/test  --username test   --groups test
-```
-
-Do not update username during upsert
-
-```
-aws-auth upsert  --maproles --rolearn arn:aws:iam::00000000000:role/test  --username test   --groups test --update-username=false
+aws-auth upsert --maproles --rolearn arn:aws:iam::00000000000:role/test --username test2 --groups test --update-username=false
 ```
 
 ## Usage as a library
@@ -172,10 +159,9 @@ func someFunc(client kubernetes.Interface) error {
             "system:nodes",
         },
         WithRetries: true,
-        MinRetryTime:  time.Millisecond * 100,
-        MaxRetryTime:  time.Second * 30,
-        MaxRetryCount: 12,
-        UpdateUsername: true
+        MinRetryTime:   time.Millisecond * 100,
+        MaxRetryTime:   time.Second * 30,
+        MaxRetryCount:  12,
     }
 
     err = awsAuth.Upsert(myUpsertRole)

--- a/README.md
+++ b/README.md
@@ -126,11 +126,30 @@ Retries are configurable using the following flags
 ```
 
 
-Append group if iam role or iam user already exists
+Append group if iam role already exists
 
 ```
-aws-auth upsert  --maproles --rolearn arn:aws:iam::00000000000:role/test  --username test   --groups test --append-groups
+aws-auth upsert  --maproles --rolearn arn:aws:iam::00000000000:role/test  --username test   --groups test --append
 ```
+
+Append group if iam user already exists
+
+```
+aws-auth upsert  --maproles --rolearn arn:aws:iam::00000000000:role/test  --username test   --groups test --append
+```
+
+Update username during upsert (default is true)
+
+```
+aws-auth upsert  --maproles --rolearn arn:aws:iam::00000000000:role/test  --username test   --groups test
+```
+
+Do not update username during upsert
+
+```
+aws-auth upsert  --maproles --rolearn arn:aws:iam::00000000000:role/test  --username test   --groups test --update-username=false
+```
+
 ## Usage as a library
 
 ```go
@@ -156,6 +175,7 @@ func someFunc(client kubernetes.Interface) error {
         MinRetryTime:  time.Millisecond * 100,
         MaxRetryTime:  time.Second * 30,
         MaxRetryCount: 12,
+        UpdateUsername: true
     }
 
     err = awsAuth.Upsert(myUpsertRole)

--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ Retries are configurable using the following flags
       --retry-min-time duration   Minimum wait interval (default 200ms)
 ```
 
+
+Append group if iam role or iam user already exists
+
+```
+aws-auth upsert  --maproles --rolearn arn:aws:iam::00000000000:role/test  --username test   --groups test --append-groups
+```
 ## Usage as a library
 
 ```go

--- a/cmd/cli/upsert.go
+++ b/cmd/cli/upsert.go
@@ -59,5 +59,5 @@ func init() {
 	upsertCmd.Flags().DurationVar(&upsertArgs.MaxRetryTime, "retry-max-time", time.Second*30, "Maximum wait interval")
 	upsertCmd.Flags().IntVar(&upsertArgs.MaxRetryCount, "retry-max-count", 12, "Maximum number of retries before giving up")
 	upsertCmd.Flags().BoolVar(&upsertArgs.Append, "append", false, "append to a existing group list")
-	upsertCmd.Flags().StringVar(&upsertArgs.UpdateUsername, "update-username", "true", "set to false to not overwite username")
+	upsertCmd.Flags().BoolVar(upsertArgs.UpdateUsername, "update-username", true, "set to false to not overwite username")
 }

--- a/cmd/cli/upsert.go
+++ b/cmd/cli/upsert.go
@@ -58,4 +58,6 @@ func init() {
 	upsertCmd.Flags().DurationVar(&upsertArgs.MinRetryTime, "retry-min-time", time.Millisecond*200, "Minimum wait interval")
 	upsertCmd.Flags().DurationVar(&upsertArgs.MaxRetryTime, "retry-max-time", time.Second*30, "Maximum wait interval")
 	upsertCmd.Flags().IntVar(&upsertArgs.MaxRetryCount, "retry-max-count", 12, "Maximum number of retries before giving up")
+	upsertCmd.Flags().BoolVar(&upsertArgs.AppendGroups, "append-groups", false, "append to a existing group list")
+	upsertCmd.Flags().BoolVar(&upsertArgs.DontUpdateUsername, "dont-update-username", false, "if username exists, dont update it")
 }

--- a/cmd/cli/upsert.go
+++ b/cmd/cli/upsert.go
@@ -58,6 +58,6 @@ func init() {
 	upsertCmd.Flags().DurationVar(&upsertArgs.MinRetryTime, "retry-min-time", time.Millisecond*200, "Minimum wait interval")
 	upsertCmd.Flags().DurationVar(&upsertArgs.MaxRetryTime, "retry-max-time", time.Second*30, "Maximum wait interval")
 	upsertCmd.Flags().IntVar(&upsertArgs.MaxRetryCount, "retry-max-count", 12, "Maximum number of retries before giving up")
-	upsertCmd.Flags().BoolVar(&upsertArgs.AppendGroups, "append-groups", false, "append to a existing group list")
-	upsertCmd.Flags().BoolVar(&upsertArgs.DontUpdateUsername, "dont-update-username", false, "if username exists, dont update it")
+	upsertCmd.Flags().BoolVar(&upsertArgs.Append, "append", false, "append to a existing group list")
+	upsertCmd.Flags().BoolVar(&upsertArgs.UpdateUsername, "update-username", true, "set to false to not overwite username")
 }

--- a/cmd/cli/upsert.go
+++ b/cmd/cli/upsert.go
@@ -59,5 +59,5 @@ func init() {
 	upsertCmd.Flags().DurationVar(&upsertArgs.MaxRetryTime, "retry-max-time", time.Second*30, "Maximum wait interval")
 	upsertCmd.Flags().IntVar(&upsertArgs.MaxRetryCount, "retry-max-count", 12, "Maximum number of retries before giving up")
 	upsertCmd.Flags().BoolVar(&upsertArgs.Append, "append", false, "append to a existing group list")
-	upsertCmd.Flags().BoolVar(&upsertArgs.UpdateUsername, "update-username", true, "set to false to not overwite username")
+	upsertCmd.Flags().StringVar(&upsertArgs.UpdateUsername, "update-username", "true", "set to false to not overwite username")
 }

--- a/pkg/mapper/types.go
+++ b/pkg/mapper/types.go
@@ -77,22 +77,22 @@ const (
 
 // MapperArguments are the arguments for removing a mapRole or mapUsers
 type MapperArguments struct {
-	KubeconfigPath     string
-	OperationType      OperationType
-	MapRoles           bool
-	MapUsers           bool
-	Force              bool
-	Username           string
-	RoleARN            string
-	UserARN            string
-	Groups             []string
-	WithRetries        bool
-	MinRetryTime       time.Duration
-	MaxRetryTime       time.Duration
-	MaxRetryCount      int
-	IsGlobal           bool
-	AppendGroups       bool
-	DontUpdateUsername bool
+	KubeconfigPath string
+	OperationType  OperationType
+	MapRoles       bool
+	MapUsers       bool
+	Force          bool
+	Username       string
+	RoleARN        string
+	UserARN        string
+	Groups         []string
+	WithRetries    bool
+	MinRetryTime   time.Duration
+	MaxRetryTime   time.Duration
+	MaxRetryCount  int
+	IsGlobal       bool
+	Append         bool
+	UpdateUsername bool
 }
 
 func (args *MapperArguments) Validate() {
@@ -243,4 +243,9 @@ func WithRetry(fn func(*MapperArguments) error, args *MapperArguments) error {
 		return nil
 	}
 	return errors.Wrap(err, "waiter timed out")
+}
+
+type UpsertOptions struct {
+	Append         bool
+	UpdateUsername bool
 }

--- a/pkg/mapper/types.go
+++ b/pkg/mapper/types.go
@@ -50,6 +50,7 @@ func New(client kubernetes.Interface, isCommandline bool) *AuthMapper {
 var (
 	DefaultRetryerBackoffFactor float64 = 2.0
 	DefaultRetryerBackoffJitter         = true
+	UpdateUsernameArgumentTrue  bool    = true
 )
 
 // AwsAuthData represents the data of the aws-auth configmap
@@ -77,23 +78,22 @@ const (
 
 // MapperArguments are the arguments for removing a mapRole or mapUsers
 type MapperArguments struct {
-	KubeconfigPath     string
-	OperationType      OperationType
-	MapRoles           bool
-	MapUsers           bool
-	Force              bool
-	Username           string
-	RoleARN            string
-	UserARN            string
-	Groups             []string
-	WithRetries        bool
-	MinRetryTime       time.Duration
-	MaxRetryTime       time.Duration
-	MaxRetryCount      int
-	IsGlobal           bool
-	Append             bool
-	UpdateUsername     string
-	UpdateUsernameBool bool
+	KubeconfigPath string
+	OperationType  OperationType
+	MapRoles       bool
+	MapUsers       bool
+	Force          bool
+	Username       string
+	RoleARN        string
+	UserARN        string
+	Groups         []string
+	WithRetries    bool
+	MinRetryTime   time.Duration
+	MaxRetryTime   time.Duration
+	MaxRetryCount  int
+	IsGlobal       bool
+	Append         bool
+	UpdateUsername *bool
 }
 
 func (args *MapperArguments) Validate() {
@@ -125,13 +125,17 @@ func (args *MapperArguments) Validate() {
 		}
 	}
 
-	switch update := args.UpdateUsername; update {
-	case "false":
-		args.UpdateUsernameBool = false
-	case "true":
-		args.UpdateUsernameBool = true
-	default:
-		args.UpdateUsernameBool = true
+	// switch update := args.UpdateUsername; update {
+	// case "false":
+	// 	args.UpdateUsernameBool = false
+	// case "true":
+	// 	args.UpdateUsernameBool = true
+	// default:
+	// 	args.UpdateUsernameBool = true
+	// }
+
+	if args.UpdateUsername == nil {
+		args.UpdateUsername = &UpdateUsernameArgumentTrue
 	}
 
 }

--- a/pkg/mapper/types.go
+++ b/pkg/mapper/types.go
@@ -125,15 +125,6 @@ func (args *MapperArguments) Validate() {
 		}
 	}
 
-	// switch update := args.UpdateUsername; update {
-	// case "false":
-	// 	args.UpdateUsernameBool = false
-	// case "true":
-	// 	args.UpdateUsernameBool = true
-	// default:
-	// 	args.UpdateUsernameBool = true
-	// }
-
 	if args.UpdateUsername == nil {
 		args.UpdateUsername = &UpdateUsernameArgumentTrue
 	}

--- a/pkg/mapper/types.go
+++ b/pkg/mapper/types.go
@@ -77,22 +77,23 @@ const (
 
 // MapperArguments are the arguments for removing a mapRole or mapUsers
 type MapperArguments struct {
-	KubeconfigPath string
-	OperationType  OperationType
-	MapRoles       bool
-	MapUsers       bool
-	Force          bool
-	Username       string
-	RoleARN        string
-	UserARN        string
-	Groups         []string
-	WithRetries    bool
-	MinRetryTime   time.Duration
-	MaxRetryTime   time.Duration
-	MaxRetryCount  int
-	IsGlobal       bool
-	Append         bool
-	UpdateUsername bool
+	KubeconfigPath     string
+	OperationType      OperationType
+	MapRoles           bool
+	MapUsers           bool
+	Force              bool
+	Username           string
+	RoleARN            string
+	UserARN            string
+	Groups             []string
+	WithRetries        bool
+	MinRetryTime       time.Duration
+	MaxRetryTime       time.Duration
+	MaxRetryCount      int
+	IsGlobal           bool
+	Append             bool
+	UpdateUsername     string
+	UpdateUsernameBool bool
 }
 
 func (args *MapperArguments) Validate() {
@@ -123,6 +124,16 @@ func (args *MapperArguments) Validate() {
 			log.Fatal("error: must select --mapusers or --maproles")
 		}
 	}
+
+	switch update := args.UpdateUsername; update {
+	case "false":
+		args.UpdateUsernameBool = false
+	case "true":
+		args.UpdateUsernameBool = true
+	default:
+		args.UpdateUsernameBool = true
+	}
+
 }
 
 // RolesAuthMap is the basic structure of a mapRoles authentication object

--- a/pkg/mapper/types.go
+++ b/pkg/mapper/types.go
@@ -77,20 +77,22 @@ const (
 
 // MapperArguments are the arguments for removing a mapRole or mapUsers
 type MapperArguments struct {
-	KubeconfigPath string
-	OperationType  OperationType
-	MapRoles       bool
-	MapUsers       bool
-	Force          bool
-	Username       string
-	RoleARN        string
-	UserARN        string
-	Groups         []string
-	WithRetries    bool
-	MinRetryTime   time.Duration
-	MaxRetryTime   time.Duration
-	MaxRetryCount  int
-	IsGlobal       bool
+	KubeconfigPath     string
+	OperationType      OperationType
+	MapRoles           bool
+	MapUsers           bool
+	Force              bool
+	Username           string
+	RoleARN            string
+	UserARN            string
+	Groups             []string
+	WithRetries        bool
+	MinRetryTime       time.Duration
+	MaxRetryTime       time.Duration
+	MaxRetryCount      int
+	IsGlobal           bool
+	AppendGroups       bool
+	DontUpdateUsername bool
 }
 
 func (args *MapperArguments) Validate() {
@@ -198,6 +200,18 @@ func (r *RolesAuthMap) SetUsername(v string) *RolesAuthMap {
 // SetGroups sets the Groups value
 func (r *RolesAuthMap) SetGroups(g []string) *RolesAuthMap {
 	r.Groups = g
+	return r
+}
+
+// AppendGroups sets the Groups value
+func (r *UsersAuthMap) AppendGroups(g []string) *UsersAuthMap {
+	r.Groups = append(r.Groups, g...)
+	return r
+}
+
+// AppendGroups sets the Groups value
+func (r *RolesAuthMap) AppendGroups(g []string) *RolesAuthMap {
+	r.Groups = append(r.Groups, g...)
 	return r
 }
 

--- a/pkg/mapper/upsert.go
+++ b/pkg/mapper/upsert.go
@@ -152,7 +152,7 @@ func (b *AuthMapper) upsertAuth(args *MapperArguments) error {
 
 	opts := &UpsertOptions{
 		Append:         args.Append,
-		UpdateUsername: args.UpdateUsernameBool,
+		UpdateUsername: *args.UpdateUsername,
 	}
 
 	if args.MapRoles {

--- a/pkg/mapper/upsert.go
+++ b/pkg/mapper/upsert.go
@@ -152,7 +152,7 @@ func (b *AuthMapper) upsertAuth(args *MapperArguments) error {
 
 	opts := &UpsertOptions{
 		Append:         args.Append,
-		UpdateUsername: args.UpdateUsername,
+		UpdateUsername: args.UpdateUsernameBool,
 	}
 
 	if args.MapRoles {

--- a/pkg/mapper/upsert_test.go
+++ b/pkg/mapper/upsert_test.go
@@ -31,18 +31,20 @@ func TestMapper_UpsertInsert(t *testing.T) {
 	create_MockConfigMap(client)
 
 	err := mapper.Upsert(&MapperArguments{
-		MapRoles: true,
-		RoleARN:  "arn:aws:iam::00000000000:role/node-2",
-		Username: "system:node:{{EC2PrivateDNSName}}",
-		Groups:   []string{"system:bootstrappers", "system:nodes"},
+		MapRoles:       true,
+		RoleARN:        "arn:aws:iam::00000000000:role/node-2",
+		Username:       "system:node:{{EC2PrivateDNSName}}",
+		Groups:         []string{"system:bootstrappers", "system:nodes"},
+		UpdateUsername: true,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = mapper.Upsert(&MapperArguments{
-		MapUsers: true,
-		UserARN:  "arn:aws:iam::00000000000:user/user-2",
-		Username: "admin",
-		Groups:   []string{"system:masters"},
+		MapUsers:       true,
+		UserARN:        "arn:aws:iam::00000000000:user/user-2",
+		Username:       "admin",
+		Groups:         []string{"system:masters"},
+		UpdateUsername: true,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -60,18 +62,20 @@ func TestMapper_UpsertUpdate(t *testing.T) {
 	create_MockConfigMap(client)
 
 	err := mapper.Upsert(&MapperArguments{
-		MapRoles: true,
-		RoleARN:  "arn:aws:iam::00000000000:role/node-1",
-		Username: "this:is:a:test",
-		Groups:   []string{"system:some-role"},
+		MapRoles:       true,
+		RoleARN:        "arn:aws:iam::00000000000:role/node-1",
+		Username:       "this:is:a:test",
+		Groups:         []string{"system:some-role"},
+		UpdateUsername: true,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = mapper.Upsert(&MapperArguments{
-		MapUsers: true,
-		UserARN:  "arn:aws:iam::00000000000:user/user-1",
-		Username: "this:is:a:test",
-		Groups:   []string{"system:some-role"},
+		MapUsers:       true,
+		UserARN:        "arn:aws:iam::00000000000:user/user-1",
+		Username:       "this:is:a:test",
+		Groups:         []string{"system:some-role"},
+		UpdateUsername: true,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -95,18 +99,20 @@ func TestMapper_UpsertNotNeeded(t *testing.T) {
 	create_MockConfigMap(client)
 
 	err := mapper.Upsert(&MapperArguments{
-		MapRoles: true,
-		RoleARN:  "arn:aws:iam::00000000000:role/node-1",
-		Username: "system:node:{{EC2PrivateDNSName}}",
-		Groups:   []string{"system:bootstrappers", "system:nodes"},
+		MapRoles:       true,
+		RoleARN:        "arn:aws:iam::00000000000:role/node-1",
+		Username:       "system:node:{{EC2PrivateDNSName}}",
+		Groups:         []string{"system:bootstrappers", "system:nodes"},
+		UpdateUsername: true,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = mapper.Upsert(&MapperArguments{
-		MapUsers: true,
-		UserARN:  "arn:aws:iam::00000000000:user/user-1",
-		Username: "admin",
-		Groups:   []string{"system:masters"},
+		MapUsers:       true,
+		UserARN:        "arn:aws:iam::00000000000:user/user-1",
+		Username:       "admin",
+		Groups:         []string{"system:masters"},
+		UpdateUsername: true,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -123,18 +129,20 @@ func TestMapper_UpsertWithCreate(t *testing.T) {
 	mapper := New(client, true)
 
 	err := mapper.Upsert(&MapperArguments{
-		MapRoles: true,
-		RoleARN:  "arn:aws:iam::00000000000:role/node-1",
-		Username: "this:is:a:test",
-		Groups:   []string{"system:some-role"},
+		MapRoles:       true,
+		RoleARN:        "arn:aws:iam::00000000000:role/node-1",
+		Username:       "this:is:a:test",
+		Groups:         []string{"system:some-role"},
+		UpdateUsername: true,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = mapper.Upsert(&MapperArguments{
-		MapUsers: true,
-		UserARN:  "arn:aws:iam::00000000000:user/user-1",
-		Username: "this:is:a:test",
-		Groups:   []string{"system:some-role"},
+		MapUsers:       true,
+		UserARN:        "arn:aws:iam::00000000000:user/user-1",
+		Username:       "this:is:a:test",
+		Groups:         []string{"system:some-role"},
+		UpdateUsername: true,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -342,26 +350,28 @@ func TestMapper_UpsertWithRetries(t *testing.T) {
 	create_MockConfigMap(client)
 
 	err := mapper.Upsert(&MapperArguments{
-		MapRoles:      true,
-		RoleARN:       "arn:aws:iam::00000000000:role/node-2",
-		Username:      "system:node:{{EC2PrivateDNSName}}",
-		Groups:        []string{"system:bootstrappers", "system:nodes"},
-		WithRetries:   true,
-		MinRetryTime:  time.Millisecond * 1,
-		MaxRetryTime:  time.Millisecond * 2,
-		MaxRetryCount: 3,
+		MapRoles:       true,
+		RoleARN:        "arn:aws:iam::00000000000:role/node-2",
+		Username:       "system:node:{{EC2PrivateDNSName}}",
+		Groups:         []string{"system:bootstrappers", "system:nodes"},
+		WithRetries:    true,
+		MinRetryTime:   time.Millisecond * 1,
+		MaxRetryTime:   time.Millisecond * 2,
+		MaxRetryCount:  3,
+		UpdateUsername: true,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = mapper.Upsert(&MapperArguments{
-		MapUsers:      true,
-		UserARN:       "arn:aws:iam::00000000000:user/user-2",
-		Username:      "admin",
-		Groups:        []string{"system:masters"},
-		WithRetries:   true,
-		MinRetryTime:  time.Millisecond * 1,
-		MaxRetryTime:  time.Millisecond * 2,
-		MaxRetryCount: 3,
+		MapUsers:       true,
+		UserARN:        "arn:aws:iam::00000000000:user/user-2",
+		Username:       "admin",
+		Groups:         []string{"system:masters"},
+		WithRetries:    true,
+		MinRetryTime:   time.Millisecond * 1,
+		MaxRetryTime:   time.Millisecond * 2,
+		MaxRetryCount:  3,
+		UpdateUsername: true,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -379,22 +389,24 @@ func TestUpsertWithRetries(t *testing.T) {
 	create_MockConfigMap(client)
 
 	err := mapper.Upsert(&MapperArguments{
-		MapRoles:      true,
-		RoleARN:       "arn:aws:iam::00000000000:role/node-1",
-		Username:      "this:is:a:test",
-		Groups:        []string{"system:some-role"},
-		WithRetries:   true,
-		MaxRetryCount: 12,
-		MaxRetryTime:  1 * time.Millisecond,
-		MinRetryTime:  1 * time.Millisecond,
+		MapRoles:       true,
+		RoleARN:        "arn:aws:iam::00000000000:role/node-1",
+		Username:       "this:is:a:test",
+		Groups:         []string{"system:some-role"},
+		WithRetries:    true,
+		MaxRetryCount:  12,
+		MaxRetryTime:   1 * time.Millisecond,
+		MinRetryTime:   1 * time.Millisecond,
+		UpdateUsername: true,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = mapper.Upsert(&MapperArguments{
-		MapUsers: true,
-		UserARN:  "arn:aws:iam::00000000000:user/user-1",
-		Username: "this:is:a:test",
-		Groups:   []string{"system:some-role"},
+		MapUsers:       true,
+		UserARN:        "arn:aws:iam::00000000000:user/user-1",
+		Username:       "this:is:a:test",
+		Groups:         []string{"system:some-role"},
+		UpdateUsername: true,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -418,20 +430,22 @@ func TestMapper_UpsertUpdateAppendGroups(t *testing.T) {
 	create_MockConfigMap(client)
 
 	err := mapper.Upsert(&MapperArguments{
-		MapRoles:     true,
-		RoleARN:      "arn:aws:iam::00000000000:role/node-1",
-		Username:     "this:is:a:test",
-		Groups:       []string{"appendedGroup"},
-		AppendGroups: true,
+		MapRoles:       true,
+		RoleARN:        "arn:aws:iam::00000000000:role/node-1",
+		Username:       "this:is:a:test",
+		Groups:         []string{"appendedGroup"},
+		Append:         true,
+		UpdateUsername: true,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = mapper.Upsert(&MapperArguments{
-		MapUsers:     true,
-		UserARN:      "arn:aws:iam::00000000000:user/user-1",
-		Username:     "this:is:a:test",
-		Groups:       []string{"appendedGroup"},
-		AppendGroups: true,
+		MapUsers:       true,
+		UserARN:        "arn:aws:iam::00000000000:user/user-1",
+		Username:       "this:is:a:test",
+		Groups:         []string{"appendedGroup"},
+		Append:         true,
+		UpdateUsername: true,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -455,20 +469,20 @@ func TestMapper_UpdateUsername(t *testing.T) {
 	create_MockConfigMap(client)
 
 	err := mapper.Upsert(&MapperArguments{
-		MapRoles:           true,
-		RoleARN:            "arn:aws:iam::00000000000:role/node-1",
-		Username:           "this:is:a:test",
-		Groups:             []string{"system:bootstrappers", "system:nodes"},
-		DontUpdateUsername: true,
+		MapRoles:       true,
+		RoleARN:        "arn:aws:iam::00000000000:role/node-1",
+		Username:       "this:is:a:test",
+		Groups:         []string{"system:bootstrappers", "system:nodes"},
+		UpdateUsername: false,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = mapper.Upsert(&MapperArguments{
-		MapUsers:           true,
-		UserARN:            "arn:aws:iam::00000000000:user/user-1",
-		Username:           "this:is:a:test",
-		Groups:             []string{"system:masters"},
-		DontUpdateUsername: true,
+		MapUsers:       true,
+		UserARN:        "arn:aws:iam::00000000000:user/user-1",
+		Username:       "this:is:a:test",
+		Groups:         []string{"system:masters"},
+		UpdateUsername: false,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/pkg/mapper/upsert_test.go
+++ b/pkg/mapper/upsert_test.go
@@ -454,12 +454,14 @@ func TestMapper_UpdateUsername(t *testing.T) {
 	mapper := New(client, true)
 	create_MockConfigMap(client)
 
+	updateUsername := false
+
 	err := mapper.Upsert(&MapperArguments{
 		MapRoles:       true,
 		RoleARN:        "arn:aws:iam::00000000000:role/node-1",
 		Username:       "this:is:a:test",
 		Groups:         []string{"system:bootstrappers", "system:nodes"},
-		UpdateUsername: "false",
+		UpdateUsername: &updateUsername,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -468,7 +470,7 @@ func TestMapper_UpdateUsername(t *testing.T) {
 		UserARN:        "arn:aws:iam::00000000000:user/user-1",
 		Username:       "this:is:a:test",
 		Groups:         []string{"system:masters"},
-		UpdateUsername: "false",
+		UpdateUsername: &updateUsername,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 

--- a/pkg/mapper/upsert_test.go
+++ b/pkg/mapper/upsert_test.go
@@ -31,20 +31,18 @@ func TestMapper_UpsertInsert(t *testing.T) {
 	create_MockConfigMap(client)
 
 	err := mapper.Upsert(&MapperArguments{
-		MapRoles:       true,
-		RoleARN:        "arn:aws:iam::00000000000:role/node-2",
-		Username:       "system:node:{{EC2PrivateDNSName}}",
-		Groups:         []string{"system:bootstrappers", "system:nodes"},
-		UpdateUsername: true,
+		MapRoles: true,
+		RoleARN:  "arn:aws:iam::00000000000:role/node-2",
+		Username: "system:node:{{EC2PrivateDNSName}}",
+		Groups:   []string{"system:bootstrappers", "system:nodes"},
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = mapper.Upsert(&MapperArguments{
-		MapUsers:       true,
-		UserARN:        "arn:aws:iam::00000000000:user/user-2",
-		Username:       "admin",
-		Groups:         []string{"system:masters"},
-		UpdateUsername: true,
+		MapUsers: true,
+		UserARN:  "arn:aws:iam::00000000000:user/user-2",
+		Username: "admin",
+		Groups:   []string{"system:masters"},
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -62,20 +60,18 @@ func TestMapper_UpsertUpdate(t *testing.T) {
 	create_MockConfigMap(client)
 
 	err := mapper.Upsert(&MapperArguments{
-		MapRoles:       true,
-		RoleARN:        "arn:aws:iam::00000000000:role/node-1",
-		Username:       "this:is:a:test",
-		Groups:         []string{"system:some-role"},
-		UpdateUsername: true,
+		MapRoles: true,
+		RoleARN:  "arn:aws:iam::00000000000:role/node-1",
+		Username: "this:is:a:test",
+		Groups:   []string{"system:some-role"},
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = mapper.Upsert(&MapperArguments{
-		MapUsers:       true,
-		UserARN:        "arn:aws:iam::00000000000:user/user-1",
-		Username:       "this:is:a:test",
-		Groups:         []string{"system:some-role"},
-		UpdateUsername: true,
+		MapUsers: true,
+		UserARN:  "arn:aws:iam::00000000000:user/user-1",
+		Username: "this:is:a:test",
+		Groups:   []string{"system:some-role"},
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -99,20 +95,18 @@ func TestMapper_UpsertNotNeeded(t *testing.T) {
 	create_MockConfigMap(client)
 
 	err := mapper.Upsert(&MapperArguments{
-		MapRoles:       true,
-		RoleARN:        "arn:aws:iam::00000000000:role/node-1",
-		Username:       "system:node:{{EC2PrivateDNSName}}",
-		Groups:         []string{"system:bootstrappers", "system:nodes"},
-		UpdateUsername: true,
+		MapRoles: true,
+		RoleARN:  "arn:aws:iam::00000000000:role/node-1",
+		Username: "system:node:{{EC2PrivateDNSName}}",
+		Groups:   []string{"system:bootstrappers", "system:nodes"},
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = mapper.Upsert(&MapperArguments{
-		MapUsers:       true,
-		UserARN:        "arn:aws:iam::00000000000:user/user-1",
-		Username:       "admin",
-		Groups:         []string{"system:masters"},
-		UpdateUsername: true,
+		MapUsers: true,
+		UserARN:  "arn:aws:iam::00000000000:user/user-1",
+		Username: "admin",
+		Groups:   []string{"system:masters"},
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -129,20 +123,18 @@ func TestMapper_UpsertWithCreate(t *testing.T) {
 	mapper := New(client, true)
 
 	err := mapper.Upsert(&MapperArguments{
-		MapRoles:       true,
-		RoleARN:        "arn:aws:iam::00000000000:role/node-1",
-		Username:       "this:is:a:test",
-		Groups:         []string{"system:some-role"},
-		UpdateUsername: true,
+		MapRoles: true,
+		RoleARN:  "arn:aws:iam::00000000000:role/node-1",
+		Username: "this:is:a:test",
+		Groups:   []string{"system:some-role"},
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = mapper.Upsert(&MapperArguments{
-		MapUsers:       true,
-		UserARN:        "arn:aws:iam::00000000000:user/user-1",
-		Username:       "this:is:a:test",
-		Groups:         []string{"system:some-role"},
-		UpdateUsername: true,
+		MapUsers: true,
+		UserARN:  "arn:aws:iam::00000000000:user/user-1",
+		Username: "this:is:a:test",
+		Groups:   []string{"system:some-role"},
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -350,28 +342,26 @@ func TestMapper_UpsertWithRetries(t *testing.T) {
 	create_MockConfigMap(client)
 
 	err := mapper.Upsert(&MapperArguments{
-		MapRoles:       true,
-		RoleARN:        "arn:aws:iam::00000000000:role/node-2",
-		Username:       "system:node:{{EC2PrivateDNSName}}",
-		Groups:         []string{"system:bootstrappers", "system:nodes"},
-		WithRetries:    true,
-		MinRetryTime:   time.Millisecond * 1,
-		MaxRetryTime:   time.Millisecond * 2,
-		MaxRetryCount:  3,
-		UpdateUsername: true,
+		MapRoles:      true,
+		RoleARN:       "arn:aws:iam::00000000000:role/node-2",
+		Username:      "system:node:{{EC2PrivateDNSName}}",
+		Groups:        []string{"system:bootstrappers", "system:nodes"},
+		WithRetries:   true,
+		MinRetryTime:  time.Millisecond * 1,
+		MaxRetryTime:  time.Millisecond * 2,
+		MaxRetryCount: 3,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = mapper.Upsert(&MapperArguments{
-		MapUsers:       true,
-		UserARN:        "arn:aws:iam::00000000000:user/user-2",
-		Username:       "admin",
-		Groups:         []string{"system:masters"},
-		WithRetries:    true,
-		MinRetryTime:   time.Millisecond * 1,
-		MaxRetryTime:   time.Millisecond * 2,
-		MaxRetryCount:  3,
-		UpdateUsername: true,
+		MapUsers:      true,
+		UserARN:       "arn:aws:iam::00000000000:user/user-2",
+		Username:      "admin",
+		Groups:        []string{"system:masters"},
+		WithRetries:   true,
+		MinRetryTime:  time.Millisecond * 1,
+		MaxRetryTime:  time.Millisecond * 2,
+		MaxRetryCount: 3,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -389,24 +379,22 @@ func TestUpsertWithRetries(t *testing.T) {
 	create_MockConfigMap(client)
 
 	err := mapper.Upsert(&MapperArguments{
-		MapRoles:       true,
-		RoleARN:        "arn:aws:iam::00000000000:role/node-1",
-		Username:       "this:is:a:test",
-		Groups:         []string{"system:some-role"},
-		WithRetries:    true,
-		MaxRetryCount:  12,
-		MaxRetryTime:   1 * time.Millisecond,
-		MinRetryTime:   1 * time.Millisecond,
-		UpdateUsername: true,
+		MapRoles:      true,
+		RoleARN:       "arn:aws:iam::00000000000:role/node-1",
+		Username:      "this:is:a:test",
+		Groups:        []string{"system:some-role"},
+		WithRetries:   true,
+		MaxRetryCount: 12,
+		MaxRetryTime:  1 * time.Millisecond,
+		MinRetryTime:  1 * time.Millisecond,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = mapper.Upsert(&MapperArguments{
-		MapUsers:       true,
-		UserARN:        "arn:aws:iam::00000000000:user/user-1",
-		Username:       "this:is:a:test",
-		Groups:         []string{"system:some-role"},
-		UpdateUsername: true,
+		MapUsers: true,
+		UserARN:  "arn:aws:iam::00000000000:user/user-1",
+		Username: "this:is:a:test",
+		Groups:   []string{"system:some-role"},
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -430,22 +418,20 @@ func TestMapper_UpsertUpdateAppendGroups(t *testing.T) {
 	create_MockConfigMap(client)
 
 	err := mapper.Upsert(&MapperArguments{
-		MapRoles:       true,
-		RoleARN:        "arn:aws:iam::00000000000:role/node-1",
-		Username:       "this:is:a:test",
-		Groups:         []string{"appendedGroup"},
-		Append:         true,
-		UpdateUsername: true,
+		MapRoles: true,
+		RoleARN:  "arn:aws:iam::00000000000:role/node-1",
+		Username: "this:is:a:test",
+		Groups:   []string{"appendedGroup"},
+		Append:   true,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
 	err = mapper.Upsert(&MapperArguments{
-		MapUsers:       true,
-		UserARN:        "arn:aws:iam::00000000000:user/user-1",
-		Username:       "this:is:a:test",
-		Groups:         []string{"appendedGroup"},
-		Append:         true,
-		UpdateUsername: true,
+		MapUsers: true,
+		UserARN:  "arn:aws:iam::00000000000:user/user-1",
+		Username: "this:is:a:test",
+		Groups:   []string{"appendedGroup"},
+		Append:   true,
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -473,7 +459,7 @@ func TestMapper_UpdateUsername(t *testing.T) {
 		RoleARN:        "arn:aws:iam::00000000000:role/node-1",
 		Username:       "this:is:a:test",
 		Groups:         []string{"system:bootstrappers", "system:nodes"},
-		UpdateUsername: false,
+		UpdateUsername: "false",
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 
@@ -482,7 +468,7 @@ func TestMapper_UpdateUsername(t *testing.T) {
 		UserARN:        "arn:aws:iam::00000000000:user/user-1",
 		Username:       "this:is:a:test",
 		Groups:         []string{"system:masters"},
-		UpdateUsername: false,
+		UpdateUsername: "false",
 	})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 


### PR DESCRIPTION
## Append Group(s) Preexisting Groups
Adds the ability to append to a group list instead of overriding. Using multiple `--groups` flags is not enough. If What ever runs the aws-auth command is unaware of preexisting groups they will be removing them.

## Do Not Update Username
Similar to the one above. If there is a preexisting entry this provides the ability to not have to hard reset that username.