### PR TITLE
adding needed flags to impersonate

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,11 @@ TYPE        	ARN                                               USERNAME         
 Role Mapping	arn:aws:iam::555555555555:role/my-new-node-group  system:node:{{EC2PrivateDNSName}}	system:bootstrappers, system:nodes
 ```
 
+use impersonate
+```
+aws-auth get|update|remove --as <username> --as-group <groupname> 
+```
+
 ## Usage as a library
 
 ```go

--- a/cmd/cli/get.go
+++ b/cmd/cli/get.go
@@ -36,7 +36,12 @@ var getCmd = &cobra.Command{
 	Short: "get provides a detailed summary of the configmap",
 	Long:  `get allows a user to output the aws-auth configmap entires in various formats`,
 	Run: func(cmd *cobra.Command, args []string) {
-		k, err := getKubernetesClient(getArgs.KubeconfigPath)
+		options := kubeOptions{
+			AsUser:   upsertArgs.AsUser,
+			AsGroups: upsertArgs.AsGroups,
+		}
+
+		k, err := getKubernetesClient(getArgs.KubeconfigPath, options)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -80,4 +85,6 @@ func init() {
 	rootCmd.AddCommand(getCmd)
 	getCmd.Flags().StringVar(&getArgs.KubeconfigPath, "kubeconfig", "", "Path to kubeconfig")
 	getCmd.Flags().StringVar(&getArgs.Format, "format", "table", "The format in which to display results (currently only 'table' supported)")
+	getCmd.Flags().StringVar(&upsertArgs.AsUser, "as", "", "Username to impersonate for the operation")
+	getCmd.Flags().StringSliceVar(&upsertArgs.AsGroups, "as-group", []string{}, "Group to impersonate for the operation, this flag can be repeated to specify multiple groups")
 }

--- a/cmd/cli/remove.go
+++ b/cmd/cli/remove.go
@@ -34,7 +34,12 @@ var removeCmd = &cobra.Command{
 	Short: "remove removes a user or role from the aws-auth configmap",
 	Long:  `remove removes a user or role from the aws-auth configmap`,
 	Run: func(cmd *cobra.Command, args []string) {
-		k, err := getKubernetesClient(removeArgs.KubeconfigPath)
+		options := kubeOptions{
+			AsUser:   upsertArgs.AsUser,
+			AsGroups: upsertArgs.AsGroups,
+		}
+
+		k, err := getKubernetesClient(getArgs.KubeconfigPath, options)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -53,7 +58,12 @@ func removeByUsernameCmd() *cobra.Command {
 		Use:   "remove-by-username",
 		Short: "remove-by-username removes all map roles and map users from the aws-auth configmap",
 		Run: func(cmd *cobra.Command, args []string) {
-			k, err := getKubernetesClient(removeArgs.KubeconfigPath)
+			options := kubeOptions{
+				AsUser:   upsertArgs.AsUser,
+				AsGroups: upsertArgs.AsGroups,
+			}
+
+			k, err := getKubernetesClient(getArgs.KubeconfigPath, options)
 			if err != nil {
 				log.Fatal(err)
 			}
@@ -90,4 +100,6 @@ func init() {
 	removeCmd.Flags().DurationVar(&removeArgs.MinRetryTime, "retry-min-time", time.Millisecond*200, "Minimum wait interval")
 	removeCmd.Flags().DurationVar(&removeArgs.MaxRetryTime, "retry-max-time", time.Second*30, "Maximum wait interval")
 	removeCmd.Flags().IntVar(&removeArgs.MaxRetryCount, "retry-max-count", 12, "Maximum number of retries before giving up")
+	removeCmd.Flags().StringVar(&upsertArgs.AsUser, "as", "", "Username to impersonate for the operation")
+	removeCmd.Flags().StringSliceVar(&upsertArgs.AsGroups, "as-group", []string{}, "Group to impersonate for the operation, this flag can be repeated to specify multiple groups")
 }

--- a/cmd/cli/root.go
+++ b/cmd/cli/root.go
@@ -25,6 +25,11 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+type kubeOptions struct {
+	AsUser   string
+	AsGroups []string
+}
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "aws-auth",
@@ -56,7 +61,7 @@ func getKubernetesLocalConfig() (*rest.Config, error) {
 	return clientCfg.ClientConfig()
 }
 
-func getKubernetesClient(kubePath string) (kubernetes.Interface, error) {
+func getKubernetesClient(kubePath string, options kubeOptions) (kubernetes.Interface, error) {
 	var (
 		config *rest.Config
 		err    error
@@ -74,6 +79,9 @@ func getKubernetesClient(kubePath string) (kubernetes.Interface, error) {
 			return nil, err
 		}
 	}
+
+	config.Impersonate.UserName = options.AsUser
+	config.Impersonate.Groups = options.AsGroups
 
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {

--- a/cmd/cli/upsert.go
+++ b/cmd/cli/upsert.go
@@ -34,7 +34,12 @@ var upsertCmd = &cobra.Command{
 	Short: "upsert updates or inserts a user or role to the aws-auth configmap",
 	Long:  `upsert updates or inserts a user or role to the aws-auth configmap`,
 	Run: func(cmd *cobra.Command, args []string) {
-		k, err := getKubernetesClient(upsertArgs.KubeconfigPath)
+		options := kubeOptions{
+			AsUser:   upsertArgs.AsUser,
+			AsGroups: upsertArgs.AsGroups,
+		}
+
+		k, err := getKubernetesClient(getArgs.KubeconfigPath, options)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -61,4 +66,6 @@ func init() {
 	upsertCmd.Flags().IntVar(&upsertArgs.MaxRetryCount, "retry-max-count", 12, "Maximum number of retries before giving up")
 	upsertCmd.Flags().BoolVar(&upsertArgs.Append, "append", false, "append to a existing group list")
 	upsertCmd.Flags().BoolVar(upsertArgs.UpdateUsername, "update-username", true, "set to false to not overwite username")
+	upsertCmd.Flags().StringVar(&upsertArgs.AsUser, "as", "", "Username to impersonate for the operation")
+	upsertCmd.Flags().StringSliceVar(&upsertArgs.AsGroups, "as-group", []string{}, "Group to impersonate for the operation, this flag can be repeated to specify multiple groups")
 }

--- a/pkg/mapper/types.go
+++ b/pkg/mapper/types.go
@@ -96,6 +96,9 @@ type MapperArguments struct {
 	IsGlobal       bool
 	Append         bool
 	UpdateUsername *bool
+
+	AsUser   string
+	AsGroups []string
 }
 
 func (args *MapperArguments) Validate() {


### PR DESCRIPTION
this pull request provides the needed flags to impersonate when using the `get`, `upsert` and `remove` commands
- `--as`
- `--as-user`


```
 go run main.go upsert -h
upsert updates or inserts a user or role to the aws-auth configmap

Usage:
  aws-auth upsert [flags]

Flags:
      --append                    append to a existing group list
      --as string                 Username to impersonate for the operation
      --as-group strings          Group to impersonate for the operation, this flag can be repeated to specify multiple groups
      --groups strings            Groups to upsert
  -h, --help                      help for upsert
      --kubeconfig string         Path to kubeconfig
      --maproles                  Upsert a role
      --mapusers                  Upsert a user
      --retry                     Retry on failure with exponential backoff
      --retry-max-count int       Maximum number of retries before giving up (default 12)
      --retry-max-time duration   Maximum wait interval (default 30s)
      --retry-min-time duration   Minimum wait interval (default 200ms)
      --rolearn string            Role ARN to upsert
      --update-username           set to false to not overwite username (default true)
      --userarn string            User ARN to upsert
      --username string           Username to upsert
```