### PR TITLE
Update GoReleaser flags for compatibility with v2.8.1+

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --rm-dist
+          args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
# fix: update GoReleaser flags for compatibility with v2.8.1+

## Motivation
The release process for aws-auth was failing due to an incompatibility with the latest version of GoReleaser (v2.8.1), which no longer supports the `--rm-dist` flag.

## Changes
- Updated the GitHub workflow release.yaml to use the correct flags for GoReleaser v2.8.1+
- Simplified the release command by removing deprecated flags
- Maintains compatibility with the latest GoReleaser action version (v6)

## Testing
- Verified the syntax of the workflow file
- Ensured compatibility with the latest GoReleaser version

## Related Issues
This PR addresses the build failure seen in the release process which showed: